### PR TITLE
Added markdown link support

### DIFF
--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -10,6 +10,12 @@ export class FileUtils {
 		const mdLinks = content.match(/\[\[([^\]]+?)\]\]/g) || [];
 		const embeds = content.match(/!\[\[([^\]]+?)\]\]/g) || [];
 
+		// Match standard markdown links: [text](path) or ![text](path)
+		// Capture group 2 is the path
+		const standardLinks = Array.from(content.matchAll(/\[([^\]]*)\]\(([^)]+)\)/g));
+		const standardEmbeds = Array.from(content.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g));
+
+		// Process WikiLinks
 		[...mdLinks, ...embeds].forEach((link) => {
 			const clean = link.replace(/!\[\[|\[\[|\]\]/g, "");
 			// For PDF files with fragment identifiers, extract only the filename before #
@@ -24,6 +30,23 @@ export class FileUtils {
 			}
 		});
 
+		// Process Markdown Links
+		[...standardLinks, ...standardEmbeds].forEach(match => {
+			const path = match[2];
+			// Ignore external links (protocol:// or mailto:)
+			if (path.match(/^([a-z][a-z0-9+.-]*:\/\/|mailto:)/i)) return;
+
+			// Decode URI (e.g. %20 -> space)
+			let cleanPath = decodeURI(path);
+
+			// Remove anchors
+			cleanPath = cleanPath.split('#')[0];
+
+			if (cleanPath) {
+				links.add(cleanPath);
+			}
+		});
+
 		return Array.from(links);
 	}
 
@@ -31,18 +54,34 @@ export class FileUtils {
 	 * Extract all links with their positions (including embeds)
 	 */
 	static extractLinksFromContent(content: string): Array<{ linkText: string; position: number }> {
-		const linkRegex = /!?\[\[([^\]]+?)\]\]/g;
 		const linkMatches: Array<{ linkText: string; position: number }> = [];
-		let match;
 
-		while ((match = linkRegex.exec(content)) !== null) {
+		// WikiLinks: [[link]] or ![[link]]
+		const wikiRegex = /!?\[\[([^\]]+?)\]\]/g;
+		let match;
+		while ((match = wikiRegex.exec(content)) !== null) {
 			const linkText = match[1].split("|")[0].split("#")[0].trim();
 			linkMatches.push({
 				linkText,
 				position: match.index,
 			});
 		}
-		return linkMatches;
+
+		// Markdown Links: [text](path) or ![text](path)
+		const mdRegex = /!?\[([^\]]*)\]\(([^)]+)\)/g;
+		while ((match = mdRegex.exec(content)) !== null) {
+			const path = match[2];
+			// Ignore external links (protocol:// or mailto:)
+			if (path.match(/^([a-z][a-z0-9+.-]*:\/\/|mailto:)/i)) continue;
+
+			const linkText = decodeURI(path).split('#')[0];
+			linkMatches.push({
+				linkText,
+				position: match.index,
+			});
+		}
+
+		return linkMatches.sort((a, b) => a.position - b.position);
 	}
 
 	/**

--- a/tests/utils/file-utils.test.ts
+++ b/tests/utils/file-utils.test.ts
@@ -34,341 +34,388 @@ describe('FileUtils', () => {
         });
     });
 
-    describe('matchesIgnore', () => {
-        it('should match exact tags', () => {
-            expect(FileUtils.matchesIgnore('#private', ['#private'])).toBe(true);
-            expect(FileUtils.matchesIgnore('#public', ['#private'])).toBe(false);
-        });
-
-        it('should match wildcard patterns', () => {
-            expect(FileUtils.matchesIgnore('#personal/journal', ['#personal/*'])).toBe(true);
-            expect(FileUtils.matchesIgnore('#personal', ['#personal/*'])).toBe(true);
-            expect(FileUtils.matchesIgnore('#work/project', ['#personal/*'])).toBe(false);
-        });
+    it('should extract standard markdown links', () => {
+        const content = 'Check [Note 1](Note%201.md) and [Note 2](path/to/Note%202.md)';
+        const result = FileUtils.getLinkedPaths(content);
+        expect(result).toContain('Note 1.md');
+        expect(result).toContain('path/to/Note 2.md');
     });
 
-    describe('sanitizeHeaderPath', () => {
-        it('should remove markdown headers', () => {
-            const result = FileUtils.sanitizeHeaderPath(['# Header 1', '## Header 2']);
-            expect(result).toBe('Header 1/Header 2');
-        });
-
-        it('should replace invalid characters', () => {
-            const result = FileUtils.sanitizeHeaderPath(['Header/With/Slashes', 'Header:With:Colons']);
-            expect(result).toBe('Header With Slashes/Header With Colons');
-        });
-
-        it('should trim and collapse spaces', () => {
-            const result = FileUtils.sanitizeHeaderPath(['  Header   1  ']);
-            expect(result).toBe('Header 1');
-        });
+    it('should extract standard image embeds', () => {
+        const content = '![Image](img.png)';
+        const result = FileUtils.getLinkedPaths(content);
+        expect(result).toContain('img.png');
     });
 
-    describe('sortFiles', () => {
-        it('should sort markdown files before others', () => {
-            const mdFile = new TFile();
-            mdFile.extension = 'md';
-            mdFile.name = 'b.md';
-
-            const pngFile = new TFile();
-            pngFile.extension = 'png';
-            pngFile.name = 'a.png';
-
-            const files = [pngFile, mdFile];
-            const result = FileUtils.sortFiles(files);
-
-            expect(result[0]).toBe(mdFile);
-            expect(result[1]).toBe(pngFile);
-        });
-
-        it('should sort alphabetically within same type', () => {
-            const file1 = new TFile();
-            file1.extension = 'md';
-            file1.name = 'b.md';
-
-            const file2 = new TFile();
-            file2.extension = 'md';
-            file2.name = 'a.md';
-
-            const files = [file1, file2];
-            const result = FileUtils.sortFiles(files);
-
-            expect(result[0]).toBe(file2);
-            expect(result[1]).toBe(file1);
-        });
+    it('should ignore external links', () => {
+        const content = '[External](https://example.com) and [FTP](ftp://server) and [Custom](ethis://test)';
+        const result = FileUtils.getLinkedPaths(content);
+        expect(result.length).toBe(0);
     });
 
-    describe('normalizeTags', () => {
-        it('should handle undefined', () => {
-            expect(FileUtils.normalizeTags(undefined)).toEqual([]);
-        });
-
-        it('should handle single string', () => {
-            expect(FileUtils.normalizeTags('tag1')).toEqual(['#tag1']);
-            expect(FileUtils.normalizeTags('#tag1')).toEqual(['#tag1']);
-        });
-
-        it('should handle array of strings', () => {
-            expect(FileUtils.normalizeTags(['tag1', '#tag2'])).toEqual(['#tag1', '#tag2']);
-        });
-    });
-
-    describe('isPathIgnored', () => {
-        it('should match ignored folders', () => {
-            expect(FileUtils.isPathIgnored('ignored/folder/file.md', ['ignored/folder'])).toBeTruthy();
-        });
-
-        it('should not match partial folder names', () => {
-            expect(FileUtils.isPathIgnored('ignored_folder_like/file.md', ['ignored_folder'])).toBeFalsy();
-        });
-
-        it('should return false for non-matching paths', () => {
-            expect(FileUtils.isPathIgnored('valid/folder/file.md', ['ignored'])).toBeFalsy();
-        });
-    });
-
-    describe('extractLinksFromContent', () => {
-        it('should extract link text and position', () => {
-            const content = 'Start [[Link]] End';
-            const result = FileUtils.extractLinksFromContent(content);
-            expect(result).toHaveLength(1);
-            expect(result[0].linkText).toBe('Link');
-            expect(result[0].position).toBe(6);
-        });
-
-        it('should handle multiple links', () => {
-            const content = '[[Link1]] [[Link2]]';
-            const result = FileUtils.extractLinksFromContent(content);
-            expect(result).toHaveLength(2);
-            expect(result[0].linkText).toBe('Link1');
-            expect(result[1].linkText).toBe('Link2');
-        });
-
-        it('should clean link text', () => {
-            const content = '[[Link|Alias]] [[Page#Header]]';
-            const result = FileUtils.extractLinksFromContent(content);
-            expect(result[0].linkText).toBe('Link');
-            expect(result[1].linkText).toBe('Page');
-        });
-    });
-
-    describe('getHeaderPathAtPosition', () => {
-        it('should return correct path', () => {
-            const headings = [
-                { level: 1, heading: 'Title', position: { start: { offset: 0 } } },
-                { level: 2, heading: 'Section', position: { start: { offset: 50 } } }
-            ];
-            expect(FileUtils.getHeaderPathAtPosition(100, headings, 'File')).toEqual(['Title', 'Section']);
-        });
-
-        it('should respect hierarchy nesting', () => {
-            const headings = [
-                { level: 1, heading: 'H1', position: { start: { offset: 0 } } },
-                { level: 2, heading: 'H2-A', position: { start: { offset: 20 } } },
-                { level: 2, heading: 'H2-B', position: { start: { offset: 40 } } },
-                { level: 3, heading: 'H3', position: { start: { offset: 60 } } }
-            ];
-            expect(FileUtils.getHeaderPathAtPosition(70, headings, 'File')).toEqual(['H1', 'H2-B', 'H3']);
-        });
-
-        it('should skip H1 if it matches filename', () => {
-            const headings = [
-                { level: 1, heading: 'My Note', position: { start: { offset: 0 } } },
-                { level: 2, heading: 'Section', position: { start: { offset: 50 } } }
-            ];
-            expect(FileUtils.getHeaderPathAtPosition(100, headings, 'My Note')).toEqual(['Section']);
-        });
-    });
-
-    describe('getFileTags', () => {
-        const mockApp = {
-            metadataCache: {
-                getFileCache: jest.fn()
-            }
-        };
-
-        it('should return empty array if no cache', () => {
-            mockApp.metadataCache.getFileCache.mockReturnValue(null);
-            expect(FileUtils.getFileTags(new TFile(), mockApp)).toEqual([]);
-        });
-
-        it('should extract frontmatter and inline tags', () => {
-            mockApp.metadataCache.getFileCache.mockReturnValue({
-                frontmatter: { tags: ['#front'] },
-                tags: [{ tag: '#inline' }]
-            });
-            const result = FileUtils.getFileTags(new TFile(), mockApp);
-            expect(result).toContain('#front');
-            expect(result).toContain('#inline');
-        });
-    });
-
-    describe('shouldExcludeFile', () => {
-        const mockApp = {
-            metadataCache: {
-                getFileCache: jest.fn()
-            }
-        };
-
-        it('should exclude by folder', () => {
-            const file = new TFile();
-            file.path = 'ignored/folder/file.md';
-            const result = FileUtils.shouldExcludeFile(file, mockApp, ['ignored/folder'], []);
-            expect(result).toBeTruthy();
-            expect(result).toContain('Folder path matches');
-        });
-
-        it('should exclude by tag', () => {
-            const file = new TFile();
-            file.path = 'notes/file.md';
-            mockApp.metadataCache.getFileCache.mockReturnValue({
-                frontmatter: { tags: ['#ignore'] }
-            });
-
-            const result = FileUtils.shouldExcludeFile(file, mockApp, [], ['#ignore']);
-            expect(result).toBeTruthy();
-            expect(result).toContain('Tag matches');
-        });
-
-        it('should not exclude valid files', () => {
-            const file = new TFile();
-            file.path = 'notes/file.md';
-            mockApp.metadataCache.getFileCache.mockReturnValue({
-                frontmatter: { tags: ['#keep'] }
-            });
-
-            const result = FileUtils.shouldExcludeFile(file, mockApp, [], ['#ignore']);
-            expect(result).toBeFalsy();
-        });
-    });
-
-    describe('getExportPathsForFile', () => {
-        it('should return root path if no headers', () => {
-            const file = new TFile();
-            file.name = 'note.md';
-            file.path = 'note.md';
-            const headerMap = new Map();
-
-            const result = FileUtils.getExportPathsForFile(file, headerMap, false, 'Source');
-            expect(result).toEqual(['note.md']);
-        });
-
-        it('should return root path with source name', () => {
-            const file = new TFile();
-            file.name = 'note.md';
-            file.path = 'note.md';
-            const headerMap = new Map();
-
-            const result = FileUtils.getExportPathsForFile(file, headerMap, true, 'Source');
-            expect(result).toEqual(['Source/note.md']);
-        });
-
-        it('should return paths under headers', () => {
-            const file = new TFile();
-            file.name = 'note.md';
-            file.path = 'note.md';
-            const headerMap = new Map();
-            headerMap.set('note.md', [['H1', 'H2']]);
-
-            const result = FileUtils.getExportPathsForFile(file, headerMap, false, 'Source');
-            expect(result).toEqual(['H1/H2/note.md']);
-        });
-
-        it('should return paths under headers with source name', () => {
-            const file = new TFile();
-            file.name = 'note.md';
-            file.path = 'note.md';
-            const headerMap = new Map();
-            headerMap.set('note.md', [['H1']]);
-
-            const result = FileUtils.getExportPathsForFile(file, headerMap, true, 'Source');
-            expect(result).toEqual(['Source/H1/note.md']);
-        });
-    });
-
-    describe('buildHeaderHierarchyAsync', () => {
-        const mockApp = {
-            metadataCache: {
-                getFileCache: jest.fn(),
-                getFirstLinkpathDest: jest.fn()
-            },
-            vault: {
-                read: jest.fn()
-            }
-        };
-
-        const sourceFile = new TFile();
-        sourceFile.path = 'source.md';
-        sourceFile.basename = 'source';
-        sourceFile.name = 'source.md';
-
-        const linkedFile = new TFile();
-        linkedFile.path = 'linked.md';
-        linkedFile.basename = 'linked';
-        linkedFile.name = 'linked.md';
-
-        const childFile = new TFile();
-        childFile.path = 'child.md';
-        childFile.basename = 'child';
-        childFile.name = 'child.md';
-
-        beforeEach(() => {
-            jest.clearAllMocks();
-        });
-
-        it('should return empty map if no cache or headings', async () => {
-            mockApp.metadataCache.getFileCache.mockReturnValue(null);
-            const result = await FileUtils.buildHeaderHierarchyAsync(sourceFile, mockApp, [], new Map(), new Map());
-            expect(result.size).toBe(0);
-        });
-
-        it('should return empty map if no links in content', async () => {
-            mockApp.metadataCache.getFileCache.mockReturnValue({ headings: [] });
-            mockApp.vault.read.mockResolvedValue('No links here');
-
-            const result = await FileUtils.buildHeaderHierarchyAsync(sourceFile, mockApp, [], new Map(), new Map());
-            expect(result.size).toBe(0);
-        });
-
-        it('should map linked file to header path', async () => {
-            mockApp.metadataCache.getFileCache.mockReturnValue({
-                headings: [{ level: 1, heading: 'Section 1', position: { start: { offset: 0 } } }]
-            });
-            mockApp.vault.read.mockResolvedValue('Some text \n\n [[linked]]');
-            mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(linkedFile);
-
-            const result = await FileUtils.buildHeaderHierarchyAsync(sourceFile, mockApp, [], new Map(), new Map());
-
-            expect(result.has('linked.md')).toBeTruthy();
-            expect(result.get('linked.md')).toEqual([['Section 1']]);
-        });
-
-        it('should propagate header context to child files', async () => {
-            // Setup source file with link to 'linked.md' under 'Section 1'
-            mockApp.metadataCache.getFileCache.mockReturnValue({
-                headings: [{ level: 1, heading: 'Section 1', position: { start: { offset: 0 } } }]
-            });
-            mockApp.vault.read.mockResolvedValue('\n\n[[linked]]');
-            mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(linkedFile);
-
-            // Setup parent map: linked.md is parent of child.md
-            const parentMap = new Map();
-            parentMap.set('child.md', new Set(['linked.md']));
-
-            // Setup depth map
-            const depthMap = new Map();
-            depthMap.set('linked.md', 1);
-            depthMap.set('child.md', 2);
-
-            const files = [linkedFile, childFile];
-
-            const result = await FileUtils.buildHeaderHierarchyAsync(sourceFile, mockApp, files, parentMap, depthMap);
-
-            // Check direct link
-            expect(result.get('linked.md')).toEqual([['Section 1']]);
-
-            // Check propagated link (child should inherit from parent)
-            expect(result.get('child.md')).toEqual([['Section 1']]);
-        });
+    it('should ignore local anchors in markdown links', () => {
+        const content = '[Link](Note.md#header)';
+        const result = FileUtils.getLinkedPaths(content);
+        expect(result).toContain('Note.md');
     });
 });
+
+describe('matchesIgnore', () => {
+    it('should match exact tags', () => {
+        expect(FileUtils.matchesIgnore('#private', ['#private'])).toBe(true);
+        expect(FileUtils.matchesIgnore('#public', ['#private'])).toBe(false);
+    });
+
+    it('should match wildcard patterns', () => {
+        expect(FileUtils.matchesIgnore('#personal/journal', ['#personal/*'])).toBe(true);
+        expect(FileUtils.matchesIgnore('#personal', ['#personal/*'])).toBe(true);
+        expect(FileUtils.matchesIgnore('#work/project', ['#personal/*'])).toBe(false);
+    });
+});
+
+describe('sanitizeHeaderPath', () => {
+    it('should remove markdown headers', () => {
+        const result = FileUtils.sanitizeHeaderPath(['# Header 1', '## Header 2']);
+        expect(result).toBe('Header 1/Header 2');
+    });
+
+    it('should replace invalid characters', () => {
+        const result = FileUtils.sanitizeHeaderPath(['Header/With/Slashes', 'Header:With:Colons']);
+        expect(result).toBe('Header With Slashes/Header With Colons');
+    });
+
+    it('should trim and collapse spaces', () => {
+        const result = FileUtils.sanitizeHeaderPath(['  Header   1  ']);
+        expect(result).toBe('Header 1');
+    });
+});
+
+describe('sortFiles', () => {
+    it('should sort markdown files before others', () => {
+        const mdFile = new TFile();
+        mdFile.extension = 'md';
+        mdFile.name = 'b.md';
+
+        const pngFile = new TFile();
+        pngFile.extension = 'png';
+        pngFile.name = 'a.png';
+
+        const files = [pngFile, mdFile];
+        const result = FileUtils.sortFiles(files);
+
+        expect(result[0]).toBe(mdFile);
+        expect(result[1]).toBe(pngFile);
+    });
+
+    it('should sort alphabetically within same type', () => {
+        const file1 = new TFile();
+        file1.extension = 'md';
+        file1.name = 'b.md';
+
+        const file2 = new TFile();
+        file2.extension = 'md';
+        file2.name = 'a.md';
+
+        const files = [file1, file2];
+        const result = FileUtils.sortFiles(files);
+
+        expect(result[0]).toBe(file2);
+        expect(result[1]).toBe(file1);
+    });
+});
+
+describe('normalizeTags', () => {
+    it('should handle undefined', () => {
+        expect(FileUtils.normalizeTags(undefined)).toEqual([]);
+    });
+
+    it('should handle single string', () => {
+        expect(FileUtils.normalizeTags('tag1')).toEqual(['#tag1']);
+        expect(FileUtils.normalizeTags('#tag1')).toEqual(['#tag1']);
+    });
+
+    it('should handle array of strings', () => {
+        expect(FileUtils.normalizeTags(['tag1', '#tag2'])).toEqual(['#tag1', '#tag2']);
+    });
+});
+
+describe('isPathIgnored', () => {
+    it('should match ignored folders', () => {
+        expect(FileUtils.isPathIgnored('ignored/folder/file.md', ['ignored/folder'])).toBeTruthy();
+    });
+
+    it('should not match partial folder names', () => {
+        expect(FileUtils.isPathIgnored('ignored_folder_like/file.md', ['ignored_folder'])).toBeFalsy();
+    });
+
+    it('should return false for non-matching paths', () => {
+        expect(FileUtils.isPathIgnored('valid/folder/file.md', ['ignored'])).toBeFalsy();
+    });
+});
+
+describe('extractLinksFromContent', () => {
+    it('should extract link text and position', () => {
+        const content = 'Start [[Link]] End';
+        const result = FileUtils.extractLinksFromContent(content);
+        expect(result).toHaveLength(1);
+        expect(result[0].linkText).toBe('Link');
+        expect(result[0].position).toBe(6);
+    });
+
+    it('should handle multiple links', () => {
+        const content = '[[Link1]] [[Link2]]';
+        const result = FileUtils.extractLinksFromContent(content);
+        expect(result).toHaveLength(2);
+        expect(result[0].linkText).toBe('Link1');
+        expect(result[1].linkText).toBe('Link2');
+    });
+
+    it('should clean link text', () => {
+        const content = '[[Link|Alias]] [[Page#Header]]';
+        const result = FileUtils.extractLinksFromContent(content);
+        expect(result[0].linkText).toBe('Link');
+        expect(result[1].linkText).toBe('Page');
+    });
+    it('should extract standard markdown links', () => {
+        const content = 'Text [Link](File.md) more text';
+        const result = FileUtils.extractLinksFromContent(content);
+        expect(result).toHaveLength(1);
+        expect(result[0].linkText).toBe('File.md');
+    });
+
+    it('should extract mixed links sorted by position', () => {
+        const content = '[[Wiki]] then [MD](File.md)';
+        const result = FileUtils.extractLinksFromContent(content);
+        expect(result).toHaveLength(2);
+        expect(result[0].linkText).toBe('Wiki');
+        expect(result[1].linkText).toBe('File.md');
+    });
+
+    it('should ignore external markdown links', () => {
+        const content = '[Google](https://google.com) and [Custom](ethis://test)';
+        const result = FileUtils.extractLinksFromContent(content);
+        expect(result).toHaveLength(0);
+    });
+});
+
+
+describe('getHeaderPathAtPosition', () => {
+    it('should return correct path', () => {
+        const headings = [
+            { level: 1, heading: 'Title', position: { start: { offset: 0 } } },
+            { level: 2, heading: 'Section', position: { start: { offset: 50 } } }
+        ];
+        expect(FileUtils.getHeaderPathAtPosition(100, headings, 'File')).toEqual(['Title', 'Section']);
+    });
+
+    it('should respect hierarchy nesting', () => {
+        const headings = [
+            { level: 1, heading: 'H1', position: { start: { offset: 0 } } },
+            { level: 2, heading: 'H2-A', position: { start: { offset: 20 } } },
+            { level: 2, heading: 'H2-B', position: { start: { offset: 40 } } },
+            { level: 3, heading: 'H3', position: { start: { offset: 60 } } }
+        ];
+        expect(FileUtils.getHeaderPathAtPosition(70, headings, 'File')).toEqual(['H1', 'H2-B', 'H3']);
+    });
+
+    it('should skip H1 if it matches filename', () => {
+        const headings = [
+            { level: 1, heading: 'My Note', position: { start: { offset: 0 } } },
+            { level: 2, heading: 'Section', position: { start: { offset: 50 } } }
+        ];
+        expect(FileUtils.getHeaderPathAtPosition(100, headings, 'My Note')).toEqual(['Section']);
+    });
+});
+
+describe('getFileTags', () => {
+    const mockApp = {
+        metadataCache: {
+            getFileCache: jest.fn()
+        }
+    };
+
+    it('should return empty array if no cache', () => {
+        mockApp.metadataCache.getFileCache.mockReturnValue(null);
+        expect(FileUtils.getFileTags(new TFile(), mockApp)).toEqual([]);
+    });
+
+    it('should extract frontmatter and inline tags', () => {
+        mockApp.metadataCache.getFileCache.mockReturnValue({
+            frontmatter: { tags: ['#front'] },
+            tags: [{ tag: '#inline' }]
+        });
+        const result = FileUtils.getFileTags(new TFile(), mockApp);
+        expect(result).toContain('#front');
+        expect(result).toContain('#inline');
+    });
+});
+
+describe('shouldExcludeFile', () => {
+    const mockApp = {
+        metadataCache: {
+            getFileCache: jest.fn()
+        }
+    };
+
+    it('should exclude by folder', () => {
+        const file = new TFile();
+        file.path = 'ignored/folder/file.md';
+        const result = FileUtils.shouldExcludeFile(file, mockApp, ['ignored/folder'], []);
+        expect(result).toBeTruthy();
+        expect(result).toContain('Folder path matches');
+    });
+
+    it('should exclude by tag', () => {
+        const file = new TFile();
+        file.path = 'notes/file.md';
+        mockApp.metadataCache.getFileCache.mockReturnValue({
+            frontmatter: { tags: ['#ignore'] }
+        });
+
+        const result = FileUtils.shouldExcludeFile(file, mockApp, [], ['#ignore']);
+        expect(result).toBeTruthy();
+        expect(result).toContain('Tag matches');
+    });
+
+    it('should not exclude valid files', () => {
+        const file = new TFile();
+        file.path = 'notes/file.md';
+        mockApp.metadataCache.getFileCache.mockReturnValue({
+            frontmatter: { tags: ['#keep'] }
+        });
+
+        const result = FileUtils.shouldExcludeFile(file, mockApp, [], ['#ignore']);
+        expect(result).toBeFalsy();
+    });
+});
+
+describe('getExportPathsForFile', () => {
+    it('should return root path if no headers', () => {
+        const file = new TFile();
+        file.name = 'note.md';
+        file.path = 'note.md';
+        const headerMap = new Map();
+
+        const result = FileUtils.getExportPathsForFile(file, headerMap, false, 'Source');
+        expect(result).toEqual(['note.md']);
+    });
+
+    it('should return root path with source name', () => {
+        const file = new TFile();
+        file.name = 'note.md';
+        file.path = 'note.md';
+        const headerMap = new Map();
+
+        const result = FileUtils.getExportPathsForFile(file, headerMap, true, 'Source');
+        expect(result).toEqual(['Source/note.md']);
+    });
+
+    it('should return paths under headers', () => {
+        const file = new TFile();
+        file.name = 'note.md';
+        file.path = 'note.md';
+        const headerMap = new Map();
+        headerMap.set('note.md', [['H1', 'H2']]);
+
+        const result = FileUtils.getExportPathsForFile(file, headerMap, false, 'Source');
+        expect(result).toEqual(['H1/H2/note.md']);
+    });
+
+    it('should return paths under headers with source name', () => {
+        const file = new TFile();
+        file.name = 'note.md';
+        file.path = 'note.md';
+        const headerMap = new Map();
+        headerMap.set('note.md', [['H1']]);
+
+        const result = FileUtils.getExportPathsForFile(file, headerMap, true, 'Source');
+        expect(result).toEqual(['Source/H1/note.md']);
+    });
+});
+
+describe('buildHeaderHierarchyAsync', () => {
+    const mockApp = {
+        metadataCache: {
+            getFileCache: jest.fn(),
+            getFirstLinkpathDest: jest.fn()
+        },
+        vault: {
+            read: jest.fn()
+        }
+    };
+
+    const sourceFile = new TFile();
+    sourceFile.path = 'source.md';
+    sourceFile.basename = 'source';
+    sourceFile.name = 'source.md';
+
+    const linkedFile = new TFile();
+    linkedFile.path = 'linked.md';
+    linkedFile.basename = 'linked';
+    linkedFile.name = 'linked.md';
+
+    const childFile = new TFile();
+    childFile.path = 'child.md';
+    childFile.basename = 'child';
+    childFile.name = 'child.md';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return empty map if no cache or headings', async () => {
+        mockApp.metadataCache.getFileCache.mockReturnValue(null);
+        const result = await FileUtils.buildHeaderHierarchyAsync(sourceFile, mockApp, [], new Map(), new Map());
+        expect(result.size).toBe(0);
+    });
+
+    it('should return empty map if no links in content', async () => {
+        mockApp.metadataCache.getFileCache.mockReturnValue({ headings: [] });
+        mockApp.vault.read.mockResolvedValue('No links here');
+
+        const result = await FileUtils.buildHeaderHierarchyAsync(sourceFile, mockApp, [], new Map(), new Map());
+        expect(result.size).toBe(0);
+    });
+
+    it('should map linked file to header path', async () => {
+        mockApp.metadataCache.getFileCache.mockReturnValue({
+            headings: [{ level: 1, heading: 'Section 1', position: { start: { offset: 0 } } }]
+        });
+        mockApp.vault.read.mockResolvedValue('Some text \n\n [[linked]]');
+        mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(linkedFile);
+
+        const result = await FileUtils.buildHeaderHierarchyAsync(sourceFile, mockApp, [], new Map(), new Map());
+
+        expect(result.has('linked.md')).toBeTruthy();
+        expect(result.get('linked.md')).toEqual([['Section 1']]);
+    });
+
+    it('should propagate header context to child files', async () => {
+        // Setup source file with link to 'linked.md' under 'Section 1'
+        mockApp.metadataCache.getFileCache.mockReturnValue({
+            headings: [{ level: 1, heading: 'Section 1', position: { start: { offset: 0 } } }]
+        });
+        mockApp.vault.read.mockResolvedValue('\n\n[[linked]]');
+        mockApp.metadataCache.getFirstLinkpathDest.mockReturnValue(linkedFile);
+
+        // Setup parent map: linked.md is parent of child.md
+        const parentMap = new Map();
+        parentMap.set('child.md', new Set(['linked.md']));
+
+        // Setup depth map
+        const depthMap = new Map();
+        depthMap.set('linked.md', 1);
+        depthMap.set('child.md', 2);
+
+        const files = [linkedFile, childFile];
+
+        const result = await FileUtils.buildHeaderHierarchyAsync(sourceFile, mockApp, files, parentMap, depthMap);
+
+        // Check direct link
+        expect(result.get('linked.md')).toEqual([['Section 1']]);
+
+        // Check propagated link (child should inherit from parent)
+        expect(result.get('child.md')).toEqual([['Section 1']]);
+    });
+});
+


### PR DESCRIPTION
- markdown link support by encoding/decoding URL encoding
- supports all 3 link modes
    - shortest path when available
    - path from current file
    - path from vault folder
- mixed usage of markdown links and wikilinks also supported.
- closes #2 