### PR TITLE
fix: handle angle brackets in markdown image links

### DIFF
--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -11,9 +11,10 @@ export class FileUtils {
 		const embeds = content.match(/!\[\[([^\]]+?)\]\]/g) || [];
 
 		// Match standard markdown links: [text](path) or ![text](path)
-		// Capture group 2 is the path
-		const standardLinks = Array.from(content.matchAll(/\[([^\]]*)\]\(([^)]+)\)/g));
-		const standardEmbeds = Array.from(content.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g));
+		// Also support angle bracket syntax: [text](<path>) or ![text](<path>)
+		// Capture group 2 is the path (with optional angle brackets)
+		const standardLinks = Array.from(content.matchAll(/\[([^\]]*)\]\(<?([^>)]+)>?\)/g));
+		const standardEmbeds = Array.from(content.matchAll(/!\[([^\]]*)\]\(<?([^>)]+)>?\)/g));
 
 
 		// Process WikiLinks
@@ -94,7 +95,8 @@ export class FileUtils {
 		}
 
 		// Markdown Links: [text](path) or ![text](path)
-		const mdRegex = /!?\[([^\]]*)\]\(([^)]+)\)/g;
+		// Also support angle bracket syntax: [text](<path>) or ![text](<path>)
+		const mdRegex = /!?\[([^\]]*)\]\(<?([^>)]+)>?\)/g;
 		while ((match = mdRegex.exec(content)) !== null) {
 			const path = match[2];
 			// Ignore external links (protocol:// or mailto:)

--- a/tests/utils/file-utils.test.ts
+++ b/tests/utils/file-utils.test.ts
@@ -39,6 +39,18 @@ describe('FileUtils', () => {
             expect(result).toEqual(['Document.pdf']);
         });
 
+        it('should handle angle bracket syntax for paths with spaces', () => {
+            const content = '![My Image](<../Imgs/image with spaces.png>)';
+            const result = FileUtils.getLinkedPaths(content);
+            expect(result).toEqual(['../Imgs/image with spaces.png']);
+        });
+
+        it('should handle angle bracket syntax for markdown links', () => {
+            const content = '[Link](<path/to/file with spaces.md>)';
+            const result = FileUtils.getLinkedPaths(content);
+            expect(result).toEqual(['path/to/file with spaces.md']);
+        });
+
         it('should return unique paths', () => {
             const content = '[[Note 1]] and [[Note 1]]';
             const result = FileUtils.getLinkedPaths(content);
@@ -306,6 +318,14 @@ describe('extractLinksFromContent', () => {
         const result = FileUtils.extractLinksFromContent(content);
         expect(result).toHaveLength(0);
     });
+
+    it('should handle angle bracket syntax in extractLinksFromContent', () => {
+        const content = '![Image](<path/to/image with spaces.png>)';
+        const result = FileUtils.extractLinksFromContent(content);
+        expect(result).toHaveLength(1);
+        expect(result[0].linkText).toBe('path/to/image with spaces.png');
+    });
+
     it('should extract standard markdown links', () => {
         const content = 'Check [Note 1](Note%201.md) and [Note 2](path/to/Note%202.md)';
         const result = FileUtils.getLinkedPaths(content);


### PR DESCRIPTION
Support markdown link syntax with angle brackets for paths containing

Fixes #15