### PR TITLE
Fix desktop directory export flow

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -34,3 +34,13 @@ export const Plugin = class { };
 export const PluginSettingTab = class { };
 export const Setting = class { };
 export const normalizePath = (path: string) => path;
+export const Platform = {
+    isDesktop: true,
+    isMobile: false,
+    isDesktopApp: false,
+    isMobileApp: false,
+    isIosApp: false,
+    isAndroidApp: false,
+    isPhone: false,
+    isTablet: false,
+};

--- a/src/ExportPlugin.ts
+++ b/src/ExportPlugin.ts
@@ -81,14 +81,14 @@ export default class ExportPlugin extends Plugin {
 			// to preserve the transient user activation context required by the File System Access API.
 			const result = await this.showExportModal(sourceFile);
 
-			if (!result.confirmed || !result.targetDir) {
+			if (!result.confirmed || !result.target) {
 				return; // User cancelled
 			}
 
 			// Perform the export
 			await this.exportService.exportFiles(
 				result.selectedFiles,
-				result.targetDir,
+				result.target,
 				result.createZip,
 				result.keepFolderStructure,
 				result.useHeaderHierarchy,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,15 @@
 import type { TFile } from "obsidian";
 
+export type ExportTarget =
+	| {
+			type: "file-system-access";
+			handle: FileSystemDirectoryHandle;
+	  }
+	| {
+			type: "local";
+			path: string;
+	  };
+
 // Plugin Settings Interface
 export interface ExportPluginSettings {
 	linkDepth: number;
@@ -19,7 +29,7 @@ export interface ExportModalResult {
 	useHeaderHierarchy: boolean; // Whether to organize files by header structure in source note
 	headerMap: Map<string, string[][]>; // Map of file paths to their header hierarchy paths
 	selectedFiles: TFile[]; // The list of files selected for export
-	targetDir?: FileSystemDirectoryHandle; // Directory selected for export (must be picked in user gesture context)
+	target?: ExportTarget; // Directory selected for export
 }
 
 // Filtered File Interface

--- a/src/ui/ExportConfirmationModal.ts
+++ b/src/ui/ExportConfirmationModal.ts
@@ -1,5 +1,5 @@
 import { Modal, TFile, App, Notice } from "obsidian";
-import { ExportModalResult, FilteredFile } from "../types";
+import type { ExportModalResult, ExportTarget, FilteredFile } from "../types";
 
 import { LinkExtractor } from "../utils/link-extractor";
 import { FilterUtils } from "../utils/filter-utils";
@@ -188,9 +188,9 @@ export class ExportConfirmationModal extends Modal {
 			// to preserve the transient user activation context required by the File System Access API.
 			// Moving this call outside the click handler (e.g., after awaiting a modal) causes
 			// DOMException on Windows: "The request is not allowed by the user agent or the platform"
-			let targetDir: FileSystemDirectoryHandle | null = null;
+			let target: ExportTarget | null = null;
 			try {
-				targetDir = await this.exportService.showDirectoryPicker();
+				target = await this.exportService.showDirectoryPicker();
 			} catch (error) {
 				// console.error removed for compliance
 				new Notice(
@@ -200,7 +200,7 @@ export class ExportConfirmationModal extends Modal {
 				return; // Don't close modal on error
 			}
 
-			if (!targetDir) {
+			if (!target) {
 				// User cancelled directory selection, keep modal open
 				return;
 			}
@@ -214,7 +214,7 @@ export class ExportConfirmationModal extends Modal {
 					this.settingsSection.useHeaderHierarchyToggle.checked,
 				selectedFiles: this.getSelectedFiles(),
 				headerMap: this.settingsSection.headerMap,
-				targetDir,
+				target,
 			});
 			this.close();
 		});

--- a/src/utils/export-service.ts
+++ b/src/utils/export-service.ts
@@ -1,8 +1,17 @@
-import { TFile, Notice, App } from "obsidian";
+import { TFile, Notice, App, Platform } from "obsidian";
 import { HeaderHierarchy } from "./header-hierarchy";
+import type { ExportTarget } from "../types";
+
+type ElectronDialog = {
+	showOpenDialog(options: {
+		properties: string[];
+	}): Promise<{ canceled: boolean; filePaths: string[] }>;
+};
 
 export class ExportService {
 	private app: App;
+	private directoryPickerPromise: Promise<ExportTarget | null> | null =
+		null;
 
 	constructor(app: App) {
 		this.app = app;
@@ -13,7 +22,7 @@ export class ExportService {
 	 */
 	async exportFiles(
 		files: TFile[],
-		targetDir: FileSystemDirectoryHandle,
+		target: ExportTarget,
 		createZip: boolean = false,
 		keepFolderStructure: boolean = false,
 		useHeaderHierarchy: boolean = false,
@@ -24,7 +33,7 @@ export class ExportService {
 			if (createZip) {
 				await this.exportAsZip(
 					files,
-					targetDir,
+					target,
 					keepFolderStructure,
 					useHeaderHierarchy,
 					headerMap,
@@ -33,7 +42,7 @@ export class ExportService {
 			} else {
 				await this.exportAsFiles(
 					files,
-					targetDir,
+					target,
 					keepFolderStructure,
 					useHeaderHierarchy,
 					headerMap,
@@ -53,7 +62,7 @@ export class ExportService {
 	 */
 	private async exportAsFiles(
 		files: TFile[],
-		targetDir: FileSystemDirectoryHandle,
+		target: ExportTarget,
 		keepFolderStructure: boolean,
 		useHeaderHierarchy: boolean,
 		headerMap: Map<string, string[][]>,
@@ -77,7 +86,7 @@ export class ExportService {
 						exportedPaths.add(exportPath);
 						await this.exportSingleFile(
 							file,
-							targetDir,
+							target,
 							keepFolderStructure,
 							useHeaderHierarchy,
 							exportPath,
@@ -90,7 +99,7 @@ export class ExportService {
 			for (const file of files) {
 				await this.exportSingleFile(
 					file,
-					targetDir,
+					target,
 					keepFolderStructure,
 					useHeaderHierarchy,
 					"",
@@ -104,7 +113,7 @@ export class ExportService {
 	 */
 	private async exportAsZip(
 		files: TFile[],
-		targetDir: FileSystemDirectoryHandle,
+		target: ExportTarget,
 		keepFolderStructure: boolean,
 		useHeaderHierarchy: boolean,
 		headerMap: Map<string, string[][]>,
@@ -153,14 +162,7 @@ export class ExportService {
 
 		// Generate ZIP content
 		const zipBlob = await zip.generateAsync({ type: "blob" });
-
-		// Save ZIP file to target directory
-		const zipFileHandle = await targetDir.getFileHandle("export.zip", {
-			create: true,
-		});
-		const writable = await zipFileHandle.createWritable();
-		await writable.write(zipBlob);
-		await writable.close();
+		await this.writeExportFile(target, "export.zip", zipBlob);
 	}
 
 	/**
@@ -168,7 +170,7 @@ export class ExportService {
 	 */
 	private async exportSingleFile(
 		file: TFile,
-		targetDir: FileSystemDirectoryHandle,
+		target: ExportTarget,
 		keepFolderStructure: boolean,
 		useHeaderHierarchy: boolean,
 		headerHierarchyPath: string = "",
@@ -187,14 +189,7 @@ export class ExportService {
 				? headerHierarchyPath
 				: this.getExportFilePath(file, keepFolderStructure);
 
-		const targetFileHandle = await this.createNestedFile(
-			targetDir,
-			targetPath,
-		);
-
-		const writable = await targetFileHandle.createWritable();
-		await writable.write(processedContent);
-		await writable.close();
+		await this.writeExportFile(target, targetPath, processedContent);
 	}
 
 	/**
@@ -232,11 +227,87 @@ export class ExportService {
 		return await currentDir.getFileHandle(fileName, { create: true });
 	}
 
+	private async writeExportFile(
+		target: ExportTarget,
+		filePath: string,
+		content: string | ArrayBuffer | Blob,
+	): Promise<void> {
+		if (target.type === "local") {
+			await this.writeLocalFile(target.path, filePath, content);
+			return;
+		}
+
+		const targetFileHandle = await this.createNestedFile(
+			target.handle,
+			filePath,
+		);
+		const writable = await targetFileHandle.createWritable();
+		await writable.write(content);
+		await writable.close();
+	}
+
+	private async writeLocalFile(
+		targetDirPath: string,
+		filePath: string,
+		content: string | ArrayBuffer | Blob,
+	): Promise<void> {
+		const fs = require("fs/promises");
+		const path = require("path");
+		const outputPath = path.join(
+			targetDirPath,
+			...filePath.split("/").filter(Boolean),
+		);
+		await fs.mkdir(path.dirname(outputPath), { recursive: true });
+
+		if (typeof content === "string") {
+			await fs.writeFile(outputPath, content, "utf8");
+			return;
+		}
+
+		if (content instanceof Blob) {
+			const arrayBuffer = await content.arrayBuffer();
+			await fs.writeFile(outputPath, Buffer.from(arrayBuffer));
+			return;
+		}
+
+		await fs.writeFile(outputPath, Buffer.from(content));
+	}
+
 	/**
 	 * Show directory picker and return selected directory
 	 */
-	async showDirectoryPicker(): Promise<FileSystemDirectoryHandle | null> {
+	async showDirectoryPicker(): Promise<ExportTarget | null> {
+		if (this.directoryPickerPromise) {
+			return this.directoryPickerPromise;
+		}
+
+		this.directoryPickerPromise = this.openDirectoryPicker();
 		try {
+			return await this.directoryPickerPromise;
+		} finally {
+			this.directoryPickerPromise = null;
+		}
+	}
+
+	private async openDirectoryPicker(): Promise<ExportTarget | null> {
+		try {
+			if (Platform.isDesktopApp) {
+				const electronDialog = this.getElectronDialog();
+				if (electronDialog) {
+					const result = await electronDialog.showOpenDialog({
+						properties: ["openDirectory", "createDirectory"],
+					});
+					if (result.canceled || result.filePaths.length === 0) {
+						return null;
+					}
+
+					return {
+						type: "local",
+						path: result.filePaths[0],
+					};
+				}
+			}
+
 			// Check if the File System Access API is supported
 			if (!("showDirectoryPicker" in window)) {
 				new Notice(
@@ -246,15 +317,28 @@ export class ExportService {
 				return null;
 			}
 
-			return await window.showDirectoryPicker({
+			const handle = await window.showDirectoryPicker({
 				mode: "readwrite",
 			});
+			return {
+				type: "file-system-access",
+				handle,
+			};
 		} catch (error) {
 			if (error.name === "AbortError") {
 				// User cancelled the directory picker
 				return null;
 			}
 			throw error;
+		}
+	}
+
+	private getElectronDialog(): ElectronDialog | null {
+		try {
+			const electron = require("electron");
+			return electron.remote?.dialog ?? null;
+		} catch (_error) {
+			return null;
 		}
 	}
 }

--- a/tests/e2e/specs/comprehensive.test.ts
+++ b/tests/e2e/specs/comprehensive.test.ts
@@ -80,9 +80,11 @@ describe("Linked Note Exporter - Comprehensive Tests", () => {
 			);
 		});
 
-		// Mock showDirectoryPicker
+		// Mock the plugin directory picker so desktop e2e tests do not open a
+		// native OS dialog.
 		await browser.execute(() => {
 			const app = (window as any).app;
+			const plugin = app.plugins.plugins["linked-note-exporter"];
 
 			async function createMockDirHandle(dirPath: string): Promise<any> {
 				return {
@@ -128,13 +130,16 @@ describe("Linked Note Exporter - Comprehensive Tests", () => {
 				(window as any).currentScenarioDir = `test-output-${id}`;
 			};
 
-			window.showDirectoryPicker = async () => {
+			plugin.exportService.showDirectoryPicker = async () => {
 				const dirName =
 					(window as any).currentScenarioDir || "test-output-default";
 				if (!(await app.vault.adapter.exists(dirName))) {
 					await app.vault.adapter.mkdir(dirName);
 				}
-				return createMockDirHandle(dirName);
+				return {
+					type: "file-system-access",
+					handle: await createMockDirHandle(dirName),
+				};
 			};
 		});
 	});

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -1,7 +1,11 @@
 import { LinkExtractor } from "../../src/utils/link-extractor";
 import { FilterUtils } from "../../src/utils/filter-utils";
 import { HeaderHierarchy } from "../../src/utils/header-hierarchy";
-import { TFile } from "obsidian";
+import { ExportService } from "../../src/utils/export-service";
+import { Platform, TFile } from "obsidian";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
 
 describe("FileUtils", () => {
 	describe("getLinkedPaths", () => {
@@ -132,6 +136,165 @@ describe("FileUtils", () => {
 			expect(
 				FilterUtils.matchesIgnore("#work/project", ["#personal/*"]),
 			).toBe(false);
+		});
+	});
+});
+
+describe("ExportService", () => {
+	describe("showDirectoryPicker", () => {
+		const originalWindow = global.window;
+		const originalDesktopApp = Platform.isDesktopApp;
+
+		afterEach(() => {
+			global.window = originalWindow;
+			Platform.isDesktopApp = originalDesktopApp;
+			jest.restoreAllMocks();
+		});
+
+		it("should reuse an in-flight File System Access directory picker request", async () => {
+			const directoryHandle = { kind: "directory", name: "export" };
+			let resolvePicker: (value: unknown) => void;
+			const pickerPromise = new Promise((resolve) => {
+				resolvePicker = resolve;
+			});
+			const showDirectoryPicker = jest.fn(() => pickerPromise);
+			global.window = { showDirectoryPicker } as unknown as Window &
+				typeof globalThis;
+
+			const service = new ExportService({} as any);
+			const firstRequest = service.showDirectoryPicker();
+			const secondRequest = service.showDirectoryPicker();
+
+			expect(showDirectoryPicker).toHaveBeenCalledTimes(1);
+
+			resolvePicker!(directoryHandle);
+			await expect(firstRequest).resolves.toEqual({
+				type: "file-system-access",
+				handle: directoryHandle,
+			});
+			await expect(secondRequest).resolves.toEqual({
+				type: "file-system-access",
+				handle: directoryHandle,
+			});
+		});
+
+		it("should use Electron's native directory picker on desktop", async () => {
+			Platform.isDesktopApp = true;
+			const showOpenDialog = jest.fn().mockResolvedValue({
+				canceled: false,
+				filePaths: ["/tmp/export-target"],
+			});
+			jest.spyOn(
+				ExportService.prototype as any,
+				"getElectronDialog",
+			).mockReturnValue({ showOpenDialog });
+			global.window = {} as Window & typeof globalThis;
+
+			const service = new ExportService({} as any);
+
+			await expect(service.showDirectoryPicker()).resolves.toEqual({
+				type: "local",
+				path: "/tmp/export-target",
+			});
+			expect(showOpenDialog).toHaveBeenCalledWith({
+				properties: ["openDirectory", "createDirectory"],
+			});
+		});
+
+		it("should reuse an in-flight Electron directory picker request", async () => {
+			Platform.isDesktopApp = true;
+			let resolvePicker: (value: unknown) => void;
+			const pickerPromise = new Promise((resolve) => {
+				resolvePicker = resolve;
+			});
+			const showOpenDialog = jest.fn(() => pickerPromise);
+			jest.spyOn(
+				ExportService.prototype as any,
+				"getElectronDialog",
+			).mockReturnValue({ showOpenDialog });
+			global.window = {} as Window & typeof globalThis;
+
+			const service = new ExportService({} as any);
+			const firstRequest = service.showDirectoryPicker();
+			const secondRequest = service.showDirectoryPicker();
+
+			expect(showOpenDialog).toHaveBeenCalledTimes(1);
+
+			resolvePicker!({
+				canceled: false,
+				filePaths: ["/tmp/export-target"],
+			});
+			await expect(firstRequest).resolves.toEqual({
+				type: "local",
+				path: "/tmp/export-target",
+			});
+			await expect(secondRequest).resolves.toEqual({
+				type: "local",
+				path: "/tmp/export-target",
+			});
+		});
+	});
+
+	describe("exportFiles", () => {
+		let tempDir: string;
+
+		afterEach(async () => {
+			if (tempDir) {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+			jest.restoreAllMocks();
+		});
+
+		it("should write exported files to a local desktop path", async () => {
+			tempDir = await fs.mkdtemp(
+				path.join(os.tmpdir(), "linked-note-exporter-"),
+			);
+			const file = new TFile();
+			file.path = "Folder/Note.md";
+			file.name = "Note.md";
+			file.extension = "md";
+			const app = {
+				vault: {
+					read: jest.fn().mockResolvedValue("# Note"),
+				},
+			};
+
+			const service = new ExportService(app as any);
+			await service.exportFiles(
+				[file],
+				{ type: "local", path: tempDir },
+				false,
+				true,
+			);
+
+			await expect(
+				fs.readFile(path.join(tempDir, "Folder", "Note.md"), "utf8"),
+			).resolves.toBe("# Note");
+		});
+
+		it("should write ZIP exports to a local desktop path", async () => {
+			tempDir = await fs.mkdtemp(
+				path.join(os.tmpdir(), "linked-note-exporter-"),
+			);
+			const file = new TFile();
+			file.path = "Note.md";
+			file.name = "Note.md";
+			file.extension = "md";
+			const app = {
+				vault: {
+					read: jest.fn().mockResolvedValue("# Note"),
+				},
+			};
+
+			const service = new ExportService(app as any);
+			await service.exportFiles(
+				[file],
+				{ type: "local", path: tempDir },
+				true,
+			);
+
+			const zipStat = await fs.stat(path.join(tempDir, "export.zip"));
+			expect(zipStat.size).toBeGreaterThan(0);
 		});
 	});
 });


### PR DESCRIPTION
## Problem

This PR fixes two related export failures in Obsidian Desktop:

1. Repeatedly clicking **Export** can trigger Chromium's picker error:

   ```text
   NotAllowedError: Failed to execute 'showDirectoryPicker' on 'Window': File picker already active.
   ```

2. More importantly, on Obsidian Desktop the export flow can silently stop after the user selects a system directory:
   - the confirmation modal closes
   - no files are written to the selected folder
   - the user gets no successful export result

The second issue is the main reason this PR goes beyond only guarding duplicate button clicks.

## Reproduction

Observed flow on Obsidian Desktop:

1. Open a markdown or canvas file.
2. Run `Export note & related files`.
3. Click **Export**.
4. Select a directory in the native/system file picker.
5. The modal closes, but the expected exported markdown files, attachments, or `export.zip` do not appear in the selected folder.

A separate but related repro is clicking **Export** more than once while the directory picker is still open. That can produce `File picker already active`.

## Root Cause

The existing implementation always used the browser File System Access API:

```ts
window.showDirectoryPicker({ mode: "readwrite" })
```

That creates two problems in this plugin's target runtime:

1. `showDirectoryPicker()` is stateful at the Chromium level. If the export button is clicked again before the previous picker resolves, Chromium rejects the second call because a picker is already active.
2. Obsidian Desktop is an Electron app. In that environment, writing through the Web `FileSystemDirectoryHandle` path is less reliable than using Electron's native dialog plus Node's filesystem APIs. The plugin can have a selected directory handle but still fail to reliably complete the actual write flow in the user's desktop export scenario.

I verified the plugin's own file collection/export logic separately with a mocked directory handle. That path can write files. The failure is concentrated around the real desktop directory selection/write target, not link traversal or header grouping.

## Solution

This PR introduces an explicit export target abstraction:

```ts
type ExportTarget =
  | { type: "file-system-access"; handle: FileSystemDirectoryHandle }
  | { type: "local"; path: string };
```

Then it changes the picker/write behavior as follows:

- On Obsidian Desktop:
  - use Electron's native `showOpenDialog({ properties: ["openDirectory", "createDirectory"] })`
  - return a local filesystem path
  - write files and ZIP output through Node `fs/promises`
- In non-desktop/browser-like environments:
  - keep the existing File System Access API path as a fallback
- For both paths:
  - keep an in-flight picker promise guard so repeated Export clicks reuse the same active picker request instead of opening a second picker

## Why This Approach

Obsidian Desktop already runs in Electron and has access to Node APIs. For local desktop export, using the native directory picker and writing to a real local path is simpler and more reliable than forcing desktop export through a browser-origin FileSystemHandle.

The File System Access API path is still kept for environments where Electron is not available, so this does not remove the existing browser-compatible implementation.

## Files Changed

- `src/types/index.ts`
  - adds the `ExportTarget` union used by the modal and export service
- `src/ui/ExportConfirmationModal.ts`
  - stores the selected export target instead of assuming a `FileSystemDirectoryHandle`
- `src/ExportPlugin.ts`
  - passes the selected `ExportTarget` to the export service
- `src/utils/export-service.ts`
  - adds desktop Electron picker support
  - adds local-path writing through `fs/promises`
  - keeps File System Access API fallback
  - keeps the in-flight picker guard
- `tests/utils/utils.test.ts`
  - adds unit coverage for File System Access picker reuse
  - adds unit coverage for Electron native directory picker selection
  - adds unit coverage for local desktop-path file export
  - adds unit coverage for local desktop-path ZIP export
- `tests/e2e/specs/comprehensive.test.ts`
  - updates the e2e picker mock to mock the plugin's export target abstraction instead of only `window.showDirectoryPicker`
- `__mocks__/obsidian.ts`
  - adds the `Platform` mock needed for desktop/non-desktop branching tests

## Verification Evidence

Unit tests:

```text
npm run test:unit -- --runInBand

PASS tests/utils/utils.test.ts
Test Suites: 1 passed, 1 total
Tests:       63 passed, 63 total
```

Build:

```text
npm run build
# tsc -noEmit -skipLibCheck && node esbuild.config.mjs production
# passed
```

End-to-end tests:

```text
npm run test:e2e

Linked Note Exporter - Comprehensive Tests
  ✓ Scenario 1: Default Export (Depth 0) - Only Source.md
  ✓ Scenario 2: Depth 1 + Subfolders - Linked files included
  ✓ Scenario 3: Depth 2 - Includes deep links
  ✓ Scenario 4: Ignore Tag - Excludes matching files
  ✓ Scenario 5: Header Hierarchy - Files grouped by headers
  ✓ Scenario 6: ZIP Export - Creates export.zip
  ✓ Scenario 7: Backlinks Toggle - Includes files that link TO source
  ✓ Scenario 8: Ignore Folders - Excludes files in ignored folders
  ✓ Scenario 9: File Deselection - Unchecked files excluded
  ✓ Scenario 10: Canvas File Export - Canvas links followed
  ✓ Scenario 11: Maintain Folders - Subdirectory paths preserved
  ✓ Scenario 12: Embedded Images - Binary attachments exported
  ✓ Scenario 13: Export Cancellation - No files exported
  ✓ Scenario 14: No File Open - Notice shown, no modal

14 passing
Spec Files: 1 passed, 1 total
```

The e2e coverage is the main acceptance evidence here because it exercises the user-facing flow: open modal, click Export, close modal, and verify the expected files exist for normal files, ZIP output, header grouping, canvas links, backlinks, ignored content, and deselection.

## Manual Acceptance Checklist

A maintainer can verify manually with Obsidian Desktop:

1. Install/load this branch in a test vault.
2. Open a markdown note with at least one linked note or attachment.
3. Run `Export note & related files`.
4. Click **Export** and choose a normal local folder.
5. Confirm files are written to that folder.
6. Enable **Create ZIP**, repeat export, and confirm `export.zip` is written.
7. Try clicking **Export** multiple times while the picker is open and confirm it does not open duplicate pickers or throw `File picker already active`.

## Risk / Compatibility Notes

- This uses Electron's native dialog only when `Platform.isDesktopApp` is true.
- If Electron dialog access is unavailable for any reason, the code falls back to the existing `window.showDirectoryPicker()` path.
- The existing File System Access API implementation is still present and used for non-desktop environments.
- The write-path logic now supports both target types, so ZIP and individual-file exports share the same destination abstraction.
